### PR TITLE
Zend_Json to Laminas\Json - Fix for Magento 2.4.6

### DIFF
--- a/Model/BuildableContentPublicRepository.php
+++ b/Model/BuildableContentPublicRepository.php
@@ -141,8 +141,8 @@ class BuildableContentPublicRepository implements BuildableContentPublicReposito
                     $styles
                 );
 
-                $response->setData('settings_content', \Zend_Json::encode($response->getSettings()));
-                $response->setData('elements_content', \Zend_Json::encode($response->getElements()));
+                $response->setData('settings_content', \Laminas\Json\Json::encode($response->getSettings()));
+                $response->setData('elements_content', \Laminas\Json\Json::encode($response->getElements()));
 
                 return $response->getData();
             };

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "goomento/module-page-builder-api",
     "description": "Rest API and GraphQL for Goomento - Magento Page Builder Extension.",
     "type": "magento2-module",
-    "version": "1.0.0",
+    "version": "1.0.0-p1",
     "license": [
         "OSL-3.0"
     ],

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "goomento/module-page-builder-api",
     "description": "Rest API and GraphQL for Goomento - Magento Page Builder Extension.",
     "type": "magento2-module",
-    "version": "1.0.0-p1",
+    "version": "1.0.1",
     "license": [
         "OSL-3.0"
     ],


### PR DESCRIPTION
Magento 2.4.6 removed the Zend_Json library from its dependencies. [See here](https://developer-stage.adobe.com/commerce/php/development/backward-incompatible-changes/highlights/#246)

> 2.4.6
> The following major backward-incompatible changes were introduced in the 2.4.6 Adobe Commerce and Magento Open Source releases:
> - ...
> - Zend_Json replaced with laminas-json
> - ...

This PR replaces all `Zend_Json` referenes with it's Laminas equivalent `Laminas\Json\Json`.

Related PR: Goomento/PageBuilder/pull/28
Related Issue: Goomento/PageBuilder/issues/26 